### PR TITLE
Fix apparent typo after second footnote

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -153,8 +153,7 @@
     <d-math>Y</d-math> that can jointly lead to the result
     <d-footnote>The corresponding <a href="https://en.wikipedia.org/wiki/Marginal_distribution" target="_blank">Wikipedia
       article</a> has a good description of the marginal distribution, including several examples.
-    </d-footnote>
-    .
+    </d-footnote>.
   </p>
 
   <p>


### PR DESCRIPTION
The published article includes a space between the second footnote and the period at the end of the sentence. That space isn't included in the source. However, the source places that period on a new line rather than immediately after the closing footnote tag. I believe this may cause the document to be rendered with a space before that period.

closes #56 

Please let me know if you have any feedback or it would be useful for me to modify this pull request in any way.