### PR TITLE
Add link to new interactive GP visualization

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -560,8 +560,8 @@
     <h3 id="FurtherReading">Further Reading</h3>
     <p>The following blog posts offer more interactive visualizations and further reading material on the topic of Gaussian processes:</p>
     <ul>
+      <li><a href="http://www.infinitecuriosity.org/vizgp/">Interactive visualization of Gaussian processes</a> by ST John that joins together the different concepts introduced throughout this article.</li>
       <li><a href="http://www.tmpl.fi/gp/">Gaussian process regression demo</a> by Tomi Peltola</li>
-      <li><a href="http://www.infinitecuriosity.org/vizgp/">Interactive visualization of Gaussian processes</a> by ST John</li>
       <li><a href="http://katbailey.github.io/post/gaussian-processes-for-dummies/">Gaussian Processes for Dummies</a> by Katherine Bailey</li>
       <li><a href="https://blog.sigopt.com/posts/intuition-behind-gaussian-processes">Intuition behind Gaussian Processes</a> by Mike McCourt</li>
       <li><a href="https://blog.dominodatalab.com/fitting-gaussian-process-models-python/">Fitting Gaussian Process Models in Python</a> by Chris Fonnesbeck</li>

--- a/public/index.html
+++ b/public/index.html
@@ -561,6 +561,7 @@
     <p>The following blog posts offer more interactive visualizations and further reading material on the topic of Gaussian processes:</p>
     <ul>
       <li><a href="http://www.tmpl.fi/gp/">Gaussian process regression demo</a> by Tomi Peltola</li>
+      <li><a href="http://www.infinitecuriosity.org/vizgp/">Interactive visualization of Gaussian processes</a> by ST John</li>
       <li><a href="http://katbailey.github.io/post/gaussian-processes-for-dummies/">Gaussian Processes for Dummies</a> by Katherine Bailey</li>
       <li><a href="https://blog.sigopt.com/posts/intuition-behind-gaussian-processes">Intuition behind Gaussian Processes</a> by Mike McCourt</li>
       <li><a href="https://blog.dominodatalab.com/fitting-gaussian-process-models-python/">Fitting Gaussian Process Models in Python</a> by Chris Fonnesbeck</li>


### PR DESCRIPTION
This PR adds a link to the hosted (live) version of https://github.com/st--/interactive-gp-visualization as suggested by @ludwigschubert on https://news.ycombinator.com/item?id=27346569 - would be great if you would be willing to include this as part of the "further reading" links:)